### PR TITLE
Hide or disable the Change Password option when appropriate

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -153,8 +153,6 @@ void Client::init()
     p->attachSlot(SIGNAL(networkCreated(NetworkId)), this, SLOT(coreNetworkCreated(NetworkId)));
     p->attachSlot(SIGNAL(networkRemoved(NetworkId)), this, SLOT(coreNetworkRemoved(NetworkId)));
 
-    p->attachSignal(this, SIGNAL(clientChangePassword(QString)));
-
     //connect(mainUi(), SIGNAL(connectToCore(const QVariantMap &)), this, SLOT(connectToCore(const QVariantMap &)));
     connect(mainUi(), SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
     connect(this, SIGNAL(connected()), mainUi(), SLOT(connectedToCore()));
@@ -386,32 +384,39 @@ void Client::setSyncedToCore()
     connect(bufferSyncer(), SIGNAL(buffersPermanentlyMerged(BufferId, BufferId)), _messageModel, SLOT(buffersPermanentlyMerged(BufferId, BufferId)));
     connect(bufferSyncer(), SIGNAL(bufferMarkedAsRead(BufferId)), SIGNAL(bufferMarkedAsRead(BufferId)));
     connect(networkModel(), SIGNAL(requestSetLastSeenMsg(BufferId, MsgId)), bufferSyncer(), SLOT(requestSetLastSeenMsg(BufferId, const MsgId &)));
-    signalProxy()->synchronize(bufferSyncer());
+
+    SignalProxy *p = signalProxy();
+
+    if ((Client::coreFeatures() & Quassel::PasswordChange)) {
+        p->attachSignal(this, SIGNAL(clientChangePassword(QString)));
+    }
+
+    p->synchronize(bufferSyncer());
 
     // create a new BufferViewManager
     Q_ASSERT(!_bufferViewManager);
-    _bufferViewManager = new ClientBufferViewManager(signalProxy(), this);
+    _bufferViewManager = new ClientBufferViewManager(p, this);
     connect(_bufferViewManager, SIGNAL(initDone()), _bufferViewOverlay, SLOT(restore()));
 
     // create AliasManager
     Q_ASSERT(!_aliasManager);
     _aliasManager = new ClientAliasManager(this);
     connect(aliasManager(), SIGNAL(initDone()), SLOT(sendBufferedUserInput()));
-    signalProxy()->synchronize(aliasManager());
+    p->synchronize(aliasManager());
 
     // create NetworkConfig
     Q_ASSERT(!_networkConfig);
     _networkConfig = new NetworkConfig("GlobalNetworkConfig", this);
-    signalProxy()->synchronize(networkConfig());
+    p->synchronize(networkConfig());
 
     // create IgnoreListManager
     Q_ASSERT(!_ignoreListManager);
     _ignoreListManager = new ClientIgnoreListManager(this);
-    signalProxy()->synchronize(ignoreListManager());
+    p->synchronize(ignoreListManager());
 
     Q_ASSERT(!_transferManager);
     _transferManager = new ClientTransferManager(this);
-    signalProxy()->synchronize(transferManager());
+    p->synchronize(transferManager());
 
     // trigger backlog request once all active bufferviews are initialized
     connect(bufferViewOverlay(), SIGNAL(initDone()), this, SLOT(requestInitialBacklog()));

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -71,8 +71,9 @@ public:
         SaslAuthentication = 0x0002,
         SaslExternal = 0x0004,
         HideInactiveNetworks = 0x0008,
+        PasswordChange = 0x0010,
 
-        NumFeatures = 0x0008
+        NumFeatures = 0x0010
     };
     Q_DECLARE_FLAGS(Features, Feature);
 

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -193,8 +193,6 @@ void MainWin::init()
     connect(Client::coreConnection(), SIGNAL(handleSslErrors(const QSslSocket *, bool *, bool *)), SLOT(handleSslErrors(const QSslSocket *, bool *, bool *)));
 #endif
 
-    connect(this, SIGNAL(changePassword(QString)), Client::instance(), SLOT(changePassword(QString)));
-
     // Setup Dock Areas
     setDockNestingEnabled(true);
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
@@ -1083,6 +1081,18 @@ void MainWin::setConnectedState()
         connect(Client::backlogManager(), SIGNAL(messagesProcessed(const QString &)), this, SLOT(showStatusBarMessage(const QString &)));
     }
 
+    disconnect(this, SIGNAL(changePassword(QString)), Client::instance(), SLOT(changePassword(QString)));
+    if (Client::internalCore()) {
+        coll->action("ChangePassword")->setVisible(false);
+    }
+    else if((Client::coreFeatures() & Quassel::PasswordChange)) {
+        connect(this, SIGNAL(changePassword(QString)), Client::instance(), SLOT(changePassword(QString)));
+        coll->action("ChangePassword")->setEnabled(true);
+    }
+    else {
+        coll->action("ChangePassword")->setEnabled(false);
+    }
+
     // _viewMenu->setEnabled(true);
     if (!Client::internalCore())
         statusBar()->showMessage(tr("Connected to core."));
@@ -1183,6 +1193,7 @@ void MainWin::setDisconnectedState()
     coll->action("ConnectCore")->setEnabled(true);
     coll->action("DisconnectCore")->setEnabled(false);
     coll->action("CoreInfo")->setEnabled(false);
+    coll->action("ChangePassword")->setEnabled(false);
     //_viewMenu->setEnabled(false);
     statusBar()->showMessage(tr("Not connected to core."));
     if (_msgProcessorStatusWidget)


### PR DESCRIPTION
Previously, the Change Password option would be shown all the
time, even the the client was connected to a core not supporting
the password change functionality or if a monolithic build was in
use.  Now, the Change Password option will be disabled if the
client is disconnected or is connected to a core not supporting the
functionality and will be hidden if a monolithic build is in use.
